### PR TITLE
Fix store vide

### DIFF
--- a/utils/store.sh
+++ b/utils/store.sh
@@ -11,7 +11,7 @@ store_init () {
 
 jv_store_update () {
     printf "Retrieving plugins database..."
-    curl -s "http://www.openjarvis.com/all.json" -H 'User-Agent: Mozilla/5; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13' > "$jv_store_file"
+    curl -s "https://www.openjarvis.com/all.json" -H 'User-Agent: Mozilla/5; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13' > "$jv_store_file"
     jv_success "Done"
 }
 


### PR DESCRIPTION
Suite au changement de nom de domaine et a l'ajout du certificat de sécurité, le site fait une redirection du protocole http vers https
La demande de Jarvis retournait donc une erreur 301 a chaque fois.
Le fix nécessite l'actualisation du fichier cache "jarvis-store.json", il est possible qu'il ne soit pas effectif au prochain lancement de jarvis mais s'appliquera ultérieurement (expiration du cache).